### PR TITLE
fix: game crashes when beetroots grow on farmland

### DIFF
--- a/src/main/java/justfatlard/dirt_slab/mixins/CropBlockMixin.java
+++ b/src/main/java/justfatlard/dirt_slab/mixins/CropBlockMixin.java
@@ -55,6 +55,7 @@ public class CropBlockMixin {
 
 	@Inject(method = "randomTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)Z"))
 	private void onCropGrow(BlockState state, ServerWorld world, BlockPos pos, Random random, CallbackInfo callbackInfo){
-		Main.happyParticles(world, pos, state.get(CropBlock.AGE));
+		CropBlock crop = (CropBlock) state.getBlock();
+		Main.happyParticles(world, pos, crop.getAge(state));
 	}
 }


### PR DESCRIPTION
**Problem**: The game crashes with `IllegalArgumentException` when beetroots attempt to grow on farmland. The `onCropGrow` method in `CropBlockMixin` uses `CropBlock.AGE` which is hardcoded to `AGE_7` (values 0-7), but beetroots use `AGE_3` (values 0-3).

**Fix**: Replaced `state.get(CropBlock.AGE)` with `crop.getAge(state)`, which uses each crop's open age property.

**Stack Trace**:

`java.lang.IllegalArgumentException: Cannot get property {name=age, values=[0, 1, 2, 3, 4, 5, 6, 7]} as it does not exist in Block{minecraft:beetroots}` 